### PR TITLE
redirected url

### DIFF
--- a/dist/ads.js
+++ b/dist/ads.js
@@ -42,6 +42,7 @@ const parseAdsTxt = async (response) => {
     result = {
       ...result,
       ...{
+        redirected_to: response.redirected ? response.url : null,
         account_count: 0,
         account_types: {
           direct: {
@@ -118,6 +119,7 @@ const parseSellersJSON = async (response) => {
     result = {
       ...result,
       ...{
+        redirected_to: response.redirected ? response.url : null,
         seller_count: 0,
         seller_types: {
           publisher: {

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -202,6 +202,7 @@ ${metricsToLogString}
 }
 
 
+// Run the tests from the command line
 if (require.main === module) {
   const runner = new WPTTestRunner();
   runner.runTests();

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -52,7 +52,7 @@ class WPTTestRunner {
       if (commentSize > 0) {
         fs.renameSync(this.testResultsFile, artifactFile);
       }
-      fs.appendFileSync(this.testResultsFile, `Webpage test results are too big for a comment, and are available as [the action's artifact]({artifact-url}).`);
+      fs.appendFileSync(this.testResultsFile, `Webpage test results that are too big for a comment are available as [the action's artifact]({artifact-url}).`);
       this.testResultsFile = artifactFile;
     }
   }


### PR DESCRIPTION
Sometimes ads transparency files redirect to the managing domains, and the original page would be listed as a publisher there. Need to use redirect URL's domain in analysis, instead of `page`.

---
**Test websites**:
  
- https://www.epicgardening.com/
- https://www.chunkbase.com/